### PR TITLE
Update README.md

### DIFF
--- a/Part 6 - Advanced Topics/README.md
+++ b/Part 6 - Advanced Topics/README.md
@@ -130,7 +130,7 @@ For this example we will share the rating values for our monkeys. If you recall,
       // ((Application)app).Windows[0].Page!.Navigation.PushAsync(new MonkeyRatingPage());
 
       // Now update it to, notice the ratingState variable
-      ((Application)app).Windows[0].Page!.Navigation.PushModalAsync(new MonkeyRatingPage(monkey, ratingState));
+      ((Application)app).Windows[0].Page!.Navigation.PushAsync(new MonkeyRatingPage(monkey, ratingState));
    }
    ```
 


### PR DESCRIPTION
When I use PushModalAsync and run the app on Windows, the "Rate a monkey" text is not shown and the back arrow is not presented. So I'm stuck without ability to navigate away from the rating page. Using PushAsync - and the monkey and ratingState parameters added, it works as described and expected. I have not tested other platforms.

Fixes #4